### PR TITLE
[monitor-hw] fix double escape for Dell servers

### DIFF
--- a/pkg/monitor-hw/cmd/root.go
+++ b/pkg/monitor-hw/cmd/root.go
@@ -74,6 +74,7 @@ var rootCmd = &cobra.Command{
 			cc := &redfish.ClientConfig{
 				AddressConfig: ac,
 				UserConfig:    uc,
+				NoEscape:      true,
 			}
 			cl, err := redfish.NewRedfishClient(cc)
 			if err != nil {


### PR DESCRIPTION
Dell servers return @odata.id as escaped URL paths.
Therefore, they must not be escaped further.

This commit adds a new configuration flag NoEscape and
set it for Dell servers.