### PR TITLE
monitor-hw: skip iDRAC reset when no-reset file exists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The container need to be run as a system service before using `idracadm7` or [`s
 rkt and systemd:
 
 ```console
+$ sudo mkdir -p /var/lib/setup-hw
+
 $ sudo systemd-run --unit=setup-hw.service \
   rkt run --net=host --dns=host --hosts-entry=host --hostname=%H \
   --insecure-options=all \
@@ -32,6 +34,7 @@ $ sudo systemd-run --unit=setup-hw.service \
   --volume sys,kind=host,source=/sys --mount volume=sys,target=/sys \
   --volume modules,kind=host,source=/lib/modules,readOnly=true --mount volume=modules,target=/lib/modules \
   --volume neco,kind=host,source=/etc/neco,readOnly=true --mount volume=neco,target=/etc/neco \
+  --volume var,kind=host,source=/var/lib/setup-hw --mount volume=var,target=/var/lib/setup-hw \
   setup-hw:latest \
     --name setup-hw \
     --caps-retain=CAP_SYS_ADMIN,CAP_SYS_CHROOT,CAP_CHOWN,CAP_FOWNER,CAP_NET_ADMIN
@@ -40,11 +43,14 @@ $ sudo systemd-run --unit=setup-hw.service \
 Docker:
 
 ```console
+$ sudo mkdir -p /var/lib/setup-hw
+
 $ docker run -d --name=setup-hw \
   --net=host --privileged \
   -v /dev:/dev \
   -v /lib/modules:/lib/modules:ro \
   -v /etc/neco:/etc/neco:ro \
+  -v /var/lib/setup-hw:/var/lib/setup-hw \
   setup-hw:latest
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,47 +8,38 @@ Versioning
 
 Follow [semantic versioning 2.0.0][semver] to choose the new version number.
 
-Prepare change log entries
---------------------------
+Change log
+----------
 
-Add notable changes since the last release to [CHANGELOG.md](CHANGELOG.md).
-It should look like:
+Notable changes since the last release to [CHANGELOG.md](CHANGELOG.md) should be listed in [CHANGELOG.md](CHANGELOG.md).
 
-```markdown
-(snip)
-## [Unreleased]
-
-### Added
-- Implement ... (#35)
-
-### Changed
-- Fix a bug in ... (#33)
-
-### Removed
-- Deprecated `-option` is removed ... (#39)
-
-(snip)
-```
+The file should respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 Bump version
 ------------
 
-1. Determine a new version number.  Let it write `$VERSION` as `VERSION=x.y.z`.
-2. Checkout `master` branch.
-3. Make a branch to release, for example by `git neco dev "$VERSION"`
-4. Edit `CHANGELOG.md` for the new version ([example][]).
-5. Commit the change and push it.
+1. Determine a new version number.  Export it as `VERSION` environment variable:
+
+    ```console
+    $ VERSION=x.y.z
+    $ export VERSION
+    ```
+
+2. Make a branch to release, for example by `git neco dev "prepare-$VERSION"`
+3. Edit `CHANGELOG.md` for the new version ([example][]).
+4. Commit the change and create a new pull request
 
     ```console
     $ git commit -a -m "Bump version to $VERSION"
     $ git neco review
     ```
 
-6. Merge this branch.
-7. Checkout `master` branch.
-8. Add a git tag, then push it.
+5. Merge the pull request.
+6. Pull `master` branch, add a git tag, then push it.
 
     ```console
+    $ git checkout master
+    $ git pull
     $ git tag "v$VERSION"
     $ git push origin "v$VERSION"
     ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ Follow [semantic versioning 2.0.0][semver] to choose the new version number.
 Change log
 ----------
 
-Notable changes since the last release to [CHANGELOG.md](CHANGELOG.md) should be listed in [CHANGELOG.md](CHANGELOG.md).
+Notable changes since the last release should be listed in [CHANGELOG.md](CHANGELOG.md).
 
 The file should respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 

--- a/docs/monitor-hw.md
+++ b/docs/monitor-hw.md
@@ -16,8 +16,7 @@ $ monitor-hw [--listen=<address>] [--interval=<interval>] [vendor-specific optio
 Description
 -----------
 
-`monitor-hw` is a monitoring daemon using [Redfish API][Redfish].
-It works as an exporter for [Prometheus][] to monitor hardware metrics.
+`monitor-hw` exposes hardware status obtained through [Redfish API][Redfish] as Prometheus metrics.
 
 When `monitor-hw` is invoked, it starts a background routine to gather
 Redfish data of the server where it runs.
@@ -32,15 +31,16 @@ As `monitor-hw` uses the standard API of Redfish instead of dedicated tools
 like `omreport`, it can support multiple types of servers from multiple
 vendors.
 
-### Vendor specific actions
+Vendor specific behaviors
+------------------------
 
-#### Dell actions
+### Dell actions
 
-`monitor-hw` starts `instsvcdrv-helper`.
+`monitor-hw` invokes `instsvcdrv-helper` for `idracadm7`.
 
 `monitor-hw` periodically resets iDRAC because it occasionally hangs.
 
-#### QEMU actions
+### QEMU actions
 
 `monitor-hw` behaves as a mock server.
 
@@ -60,13 +60,13 @@ This interval means the time between the end of a certain traversal operation
 and the beginning of the next one, so the observed interval of metrics update
 will be somewhat longer than this interval.
 
-### Vendor specific options
-
-#### Dell options
+### Dell options
 
 `--reset-interval` specifies the interval of resetting iDRAC in hours.
 The default is 24 hours.
 
+`--no-reset` specifies a file name watched by `monitor-hw`.
+While the file exists, `monitor-hw` does not reset iDRAC.
 
 Configuration files
 -------------------

--- a/pkg/monitor-hw/cmd/dell.go
+++ b/pkg/monitor-hw/cmd/dell.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/cybozu-go/log"
@@ -20,6 +21,11 @@ func monitorDell(ctx context.Context) error {
 			case <-time.After(time.Duration(opts.resetInterval) * time.Hour):
 			case <-ctx.Done():
 				return nil
+			}
+
+			if _, err := os.Stat(opts.noResetFile); err == nil {
+				// if no-reset file exists, skip reset.
+				continue
 			}
 
 			err := well.CommandContext(ctx, "/opt/dell/srvadmin/bin/idracadm7", "racreset", "soft").Run()

--- a/pkg/monitor-hw/cmd/root.go
+++ b/pkg/monitor-hw/cmd/root.go
@@ -15,15 +15,16 @@ import (
 
 var opts struct {
 	listenAddress string
-	redfishRoot   string
 	interval      int
 	resetInterval int
+	noResetFile   string
 }
 
 const (
-	defaultPort          = ":9105"
+	defaultAddress       = ":9105"
 	defaultInterval      = 60
 	defaultResetInterval = 24
+	defaultNoReset       = "/var/lib/setup-hw/no-reset"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -122,7 +123,8 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().StringVar(&opts.listenAddress, "listen", defaultPort, "listening address and port number")
+	rootCmd.Flags().StringVar(&opts.listenAddress, "listen", defaultAddress, "listening address and port number")
 	rootCmd.Flags().IntVar(&opts.interval, "interval", defaultInterval, "interval of collecting metrics in seconds")
 	rootCmd.Flags().IntVar(&opts.resetInterval, "reset-interval", defaultResetInterval, "interval of resetting iDRAC in hours (dell servers only)")
+	rootCmd.Flags().StringVar(&opts.noResetFile, "no-reset", defaultNoReset, "path of the no-reset file")
 }


### PR DESCRIPTION
The default location of `no-reset` file is `/var/lib/setup-hw`.