### PR TITLE
monitor-hw: reset iDRAC at startup

### DIFF
--- a/pkg/monitor-hw/cmd/dell.go
+++ b/pkg/monitor-hw/cmd/dell.go
@@ -13,6 +13,9 @@ func monitorDell(ctx context.Context) error {
 	if err := initDell(ctx); err != nil {
 		return err
 	}
+	if err := resetDell(ctx); err != nil {
+		return err
+	}
 
 	env := well.NewEnvironment(ctx)
 	env.Go(func(ctx context.Context) error {
@@ -28,8 +31,7 @@ func monitorDell(ctx context.Context) error {
 				continue
 			}
 
-			err := well.CommandContext(ctx, "/opt/dell/srvadmin/bin/idracadm7", "racreset", "soft").Run()
-			if err != nil {
+			if err := resetDell(ctx); err != nil {
 				log.Error("failed to reset iDRAC", map[string]interface{}{
 					log.FnError: err,
 				})
@@ -44,4 +46,8 @@ func monitorDell(ctx context.Context) error {
 
 func initDell(ctx context.Context) error {
 	return well.CommandContext(ctx, "/usr/libexec/instsvcdrv-helper", "start").Run()
+}
+
+func resetDell(ctx context.Context) error {
+	return well.CommandContext(ctx, "/opt/dell/srvadmin/bin/idracadm7", "racreset", "soft").Run()
 }


### PR DESCRIPTION
To recover from inconsistent Redfish query results,
iDRAC should be reset quickly at the beginning of the process.