### PR TITLE
Add rules for version 1.11.0

### DIFF
--- a/base-rules/dell.yaml
+++ b/base-rules/dell.yaml
@@ -36,7 +36,9 @@ Metrics:
   - Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}
   - Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkDeviceFunctions/{function}
   - Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkPorts/{port}
+  - Path: /redfish/v1/Chassis/{chassis}/PCIeSlots
   - Path: /redfish/v1/Chassis/{chassis}/Power
+  - Path: /redfish/v1/Chassis/{chassis}/Sensors/{sensor}
   - Path: /redfish/v1/Chassis/{chassis}/Thermal
   - Path: /redfish/v1/Dell/Chassis/{system}/DellAssembly/{assembly}
   - Path: /redfish/v1/Dell/Systems/{system}/DellNumericSensor/{sensor}
@@ -76,9 +78,9 @@ Metrics:
   - Path: /redfish/v1/Systems/{system}/SimpleStorage/{controller}
   - Path: /redfish/v1/Systems/{system}/Storage/{storage}
   - Path: /redfish/v1/Systems/{system}/Storage/{storage}/Drives/{device}
+  - Path: /redfish/v1/Systems/{system}/Storage/{storage}/StorageControllers/{controller}
   - Path: /redfish/v1/Systems/{system}/Storage/{storage}/Volumes
   - Path: /redfish/v1/Systems/{system}/Storage/{storage}/Volumes/{volume}
-  - Path: /redfish/v1/Systems/{system}/StorageControllers/{controller}
 
 # ./collector generate-rule --base-rule=base-rules/dell.yaml \
 #   --key=Health:health \

--- a/redfish/rendered_rules.go
+++ b/redfish/rendered_rules.go
@@ -196,6 +196,631 @@ var Rules = map[string]*CollectRule{
 			},
 		},
 	},
+	"dell_redfish_1.11.0.yml": {
+		TraverseRule: TraverseRule{
+			Root: "/redfish/v1",
+			ExcludeRules: []string{
+				"/JsonSchemas",
+				"/Accounts",
+				"/Certificates",
+				"/Jobs",
+				"/Logs",
+				"/Registries",
+				"/Roles",
+				"/Sessions",
+				"/Settings",
+				"/AccountService",
+				"/CertificateService",
+				"/EventService",
+				"/JobService",
+				"/LogServices",
+				"/SessionService",
+				"/TaskService",
+				"/TelemetryService",
+				"/UpdateService",
+				"/Power/",
+				"/Power#/",
+				"/Thermal#/",
+				"/Assembly#/",
+				"/redfish/v1/Chassis/$",
+			},
+		},
+		MetricRules: []*MetricRule{
+			{
+				Path: "/redfish/v1/Chassis/{chassis}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_networkadapters_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_networkadapters_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkDeviceFunctions/{function}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_networkadapters_networkdevicefunctions_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_networkadapters_networkdevicefunctions_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkPorts/{port}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_networkadapters_networkports_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_networkadapters_networkports_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/PCIeSlots",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Slots/{slot}/Status/State",
+						Name:    "chassis_pcieslots_slots_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/Power",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/PowerControl/{powercontrol}/PowerConsumedWatts",
+						Name:    "chassis_power_powercontrol_powerconsumedwatts",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/Health",
+						Name:    "chassis_power_powersupplies_redundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/State",
+						Name:    "chassis_power_powersupplies_redundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Status/Health",
+						Name:    "chassis_power_powersupplies_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Status/State",
+						Name:    "chassis_power_powersupplies_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/Health",
+						Name:    "chassis_power_redundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/State",
+						Name:    "chassis_power_redundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Voltages/{voltage}/Status/Health",
+						Name:    "chassis_power_voltages_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Voltages/{voltage}/Status/State",
+						Name:    "chassis_power_voltages_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/Sensors/{sensor}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_sensors_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_sensors_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/Thermal",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Fans/{fan}/Status/Health",
+						Name:    "chassis_thermal_fans_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Fans/{fan}/Status/State",
+						Name:    "chassis_thermal_fans_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/Health",
+						Name:    "chassis_thermal_redundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/State",
+						Name:    "chassis_thermal_redundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Temperatures/{temperature}/ReadingCelsius",
+						Name:    "chassis_thermal_temperatures_readingcelsius",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Temperatures/{temperature}/Status/Health",
+						Name:    "chassis_thermal_temperatures_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Temperatures/{temperature}/Status/State",
+						Name:    "chassis_thermal_temperatures_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Fabrics/{fabric}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "fabrics_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "fabrics_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "managers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "managers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "managers_ethernetinterfaces_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "managers_ethernetinterfaces_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}/NetworkProtocol",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "managers_networkprotocol_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "managers_networkprotocol_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/HostWatchdogTimer/Status/State",
+						Name:    "systems_hostwatchdogtimer_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/MemorySummary/Status/Health",
+						Name:    "systems_memorysummary_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/MemorySummary/Status/State",
+						Name:    "systems_memorysummary_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/ProcessorSummary/Status/Health",
+						Name:    "systems_processorsummary_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/ProcessorSummary/Status/State",
+						Name:    "systems_processorsummary_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/TrustedModules/{trustedmodule}/Status/State",
+						Name:    "systems_trustedmodules_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/EthernetInterfaces/{interface}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_ethernetinterfaces_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_ethernetinterfaces_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Memory/{memory}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_memory_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_memory_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Memory/{memory}/MemoryMetrics",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/HealthData/AlarmTrips/AddressParityError",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_addressparityerror",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/CorrectableECCError",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_correctableeccerror",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/SpareBlock",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_spareblock",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/Temperature",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_temperature",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/UncorrectableECCError",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_uncorrectableeccerror",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/DataLossDetected",
+						Name:    "systems_memory_memorymetrics_healthdata_datalossdetected",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/PredictedMediaLifeLeftPercent",
+						Name:    "systems_memory_memorymetrics_healthdata_predictedmedialifeleftpercent",
+						Help:    "",
+						Type:    "number",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/NetworkInterfaces/{nic}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_networkinterfaces_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_networkinterfaces_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_pciedevices_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_pciedevices_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}/PCIeFunctions/{function}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_pciedevices_pciefunctions_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_pciedevices_pciefunctions_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Processors/{processor}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_processors_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_processors_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/SimpleStorage/{controller}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_simplestorage_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_simplestorage_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/Health",
+						Name:    "systems_storage_storagecontrollers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/State",
+						Name:    "systems_storage_storagecontrollers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/Drives/{device}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/FailurePredicted",
+						Name:    "systems_storage_drives_failurepredicted",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/PredictedMediaLifeLeftPercent",
+						Name:    "systems_storage_drives_predictedmedialifeleftpercent",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_drives_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_drives_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/StorageControllers/{controller}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_storagecontrollers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_storagecontrollers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/Health",
+						Name:    "systems_storage_storagecontrollers_storagecontrollers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/State",
+						Name:    "systems_storage_storagecontrollers_storagecontrollers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/Volumes/{volume}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_volumes_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_volumes_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+		},
+	},
 	"dell_redfish_1.2.0.yml": {
 		TraverseRule: TraverseRule{
 			Root: "/redfish/v1",
@@ -1553,631 +2178,6 @@ var Rules = map[string]*CollectRule{
 					{
 						Pointer: "/Status/State",
 						Name:    "systems_storagecontrollers_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-		},
-	},
-	"dell_redfish_1.9.0.yml": {
-		TraverseRule: TraverseRule{
-			Root: "/redfish/v1",
-			ExcludeRules: []string{
-				"/JsonSchemas",
-				"/Accounts",
-				"/Certificates",
-				"/Jobs",
-				"/Logs",
-				"/Registries",
-				"/Roles",
-				"/Sessions",
-				"/Settings",
-				"/AccountService",
-				"/CertificateService",
-				"/EventService",
-				"/JobService",
-				"/LogServices",
-				"/SessionService",
-				"/TaskService",
-				"/TelemetryService",
-				"/UpdateService",
-				"/Power/",
-				"/Power#/",
-				"/Thermal#/",
-				"/Assembly#/",
-				"/redfish/v1/Chassis/$",
-			},
-		},
-		MetricRules: []*MetricRule{
-			{
-				Path: "/redfish/v1/Chassis/{chassis}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "chassis_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "chassis_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "chassis_networkadapters_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "chassis_networkadapters_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkDeviceFunctions/{function}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "chassis_networkadapters_networkdevicefunctions_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "chassis_networkadapters_networkdevicefunctions_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkPorts/{port}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "chassis_networkadapters_networkports_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "chassis_networkadapters_networkports_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Chassis/{chassis}/PCIeSlots",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Slots/{slot}/Status/State",
-						Name:    "chassis_pcieslots_slots_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Chassis/{chassis}/Power",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/PowerControl/{powercontrol}/PowerConsumedWatts",
-						Name:    "chassis_power_powercontrol_powerconsumedwatts",
-						Help:    "",
-						Type:    "number",
-					},
-					{
-						Pointer: "/PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/Health",
-						Name:    "chassis_power_powersupplies_redundancy_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/State",
-						Name:    "chassis_power_powersupplies_redundancy_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/PowerSupplies/{powersupply}/Status/Health",
-						Name:    "chassis_power_powersupplies_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/PowerSupplies/{powersupply}/Status/State",
-						Name:    "chassis_power_powersupplies_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/Redundancy/{redundancy}/Status/Health",
-						Name:    "chassis_power_redundancy_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Redundancy/{redundancy}/Status/State",
-						Name:    "chassis_power_redundancy_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/Voltages/{voltage}/Status/Health",
-						Name:    "chassis_power_voltages_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Voltages/{voltage}/Status/State",
-						Name:    "chassis_power_voltages_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Chassis/{chassis}/Sensors/{sensor}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "chassis_sensors_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "chassis_sensors_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Chassis/{chassis}/Thermal",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Fans/{fan}/Status/Health",
-						Name:    "chassis_thermal_fans_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Fans/{fan}/Status/State",
-						Name:    "chassis_thermal_fans_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/Redundancy/{redundancy}/Status/Health",
-						Name:    "chassis_thermal_redundancy_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Redundancy/{redundancy}/Status/State",
-						Name:    "chassis_thermal_redundancy_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/Temperatures/{temperature}/ReadingCelsius",
-						Name:    "chassis_thermal_temperatures_readingcelsius",
-						Help:    "",
-						Type:    "number",
-					},
-					{
-						Pointer: "/Temperatures/{temperature}/Status/Health",
-						Name:    "chassis_thermal_temperatures_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Temperatures/{temperature}/Status/State",
-						Name:    "chassis_thermal_temperatures_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Fabrics/{fabric}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "fabrics_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "fabrics_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Managers/{manager}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "managers_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "managers_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "managers_ethernetinterfaces_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "managers_ethernetinterfaces_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Managers/{manager}/NetworkProtocol",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "managers_networkprotocol_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "managers_networkprotocol_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/HostWatchdogTimer/Status/State",
-						Name:    "systems_hostwatchdogtimer_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/MemorySummary/Status/Health",
-						Name:    "systems_memorysummary_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/MemorySummary/Status/State",
-						Name:    "systems_memorysummary_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/ProcessorSummary/Status/Health",
-						Name:    "systems_processorsummary_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/ProcessorSummary/Status/State",
-						Name:    "systems_processorsummary_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/TrustedModules/{trustedmodule}/Status/State",
-						Name:    "systems_trustedmodules_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/EthernetInterfaces/{interface}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_ethernetinterfaces_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_ethernetinterfaces_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/Memory/{memory}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_memory_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_memory_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/Memory/{memory}/MemoryMetrics",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/HealthData/AlarmTrips/AddressParityError",
-						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_addressparityerror",
-						Help:    "",
-						Type:    "bool",
-					},
-					{
-						Pointer: "/HealthData/AlarmTrips/CorrectableECCError",
-						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_correctableeccerror",
-						Help:    "",
-						Type:    "bool",
-					},
-					{
-						Pointer: "/HealthData/AlarmTrips/SpareBlock",
-						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_spareblock",
-						Help:    "",
-						Type:    "bool",
-					},
-					{
-						Pointer: "/HealthData/AlarmTrips/Temperature",
-						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_temperature",
-						Help:    "",
-						Type:    "bool",
-					},
-					{
-						Pointer: "/HealthData/AlarmTrips/UncorrectableECCError",
-						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_uncorrectableeccerror",
-						Help:    "",
-						Type:    "bool",
-					},
-					{
-						Pointer: "/HealthData/DataLossDetected",
-						Name:    "systems_memory_memorymetrics_healthdata_datalossdetected",
-						Help:    "",
-						Type:    "bool",
-					},
-					{
-						Pointer: "/HealthData/PredictedMediaLifeLeftPercent",
-						Name:    "systems_memory_memorymetrics_healthdata_predictedmedialifeleftpercent",
-						Help:    "",
-						Type:    "number",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/NetworkInterfaces/{nic}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_networkinterfaces_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_networkinterfaces_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_pciedevices_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_pciedevices_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}/PCIeFunctions/{function}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_pciedevices_pciefunctions_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_pciedevices_pciefunctions_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/Processors/{processor}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_processors_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_processors_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/SimpleStorage/{controller}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Devices/{device}/Status/Health",
-						Name:    "systems_simplestorage_devices_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Devices/{device}/Status/State",
-						Name:    "systems_simplestorage_devices_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_simplestorage_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_simplestorage_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/Storage/{storage}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_storage_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_storage_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/Drives/{device}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/FailurePredicted",
-						Name:    "systems_storage_drives_failurepredicted",
-						Help:    "",
-						Type:    "bool",
-					},
-					{
-						Pointer: "/PredictedMediaLifeLeftPercent",
-						Name:    "systems_storage_drives_predictedmedialifeleftpercent",
-						Help:    "",
-						Type:    "number",
-					},
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_storage_drives_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_storage_drives_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/StorageControllers/{controller}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_storage_storagecontrollers_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_storage_storagecontrollers_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-					{
-						Pointer: "/StorageControllers/{storagecontroller}/Status/Health",
-						Name:    "systems_storage_storagecontrollers_storagecontrollers_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/StorageControllers/{storagecontroller}/Status/State",
-						Name:    "systems_storage_storagecontrollers_storagecontrollers_status_state",
-						Help:    "",
-						Type:    "state",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/Volumes/{volume}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "systems_storage_volumes_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-					{
-						Pointer: "/Status/State",
-						Name:    "systems_storage_volumes_status_state",
 						Help:    "",
 						Type:    "state",
 					},

--- a/redfish/rendered_rules.go
+++ b/redfish/rendered_rules.go
@@ -1560,6 +1560,631 @@ var Rules = map[string]*CollectRule{
 			},
 		},
 	},
+	"dell_redfish_1.9.0.yml": {
+		TraverseRule: TraverseRule{
+			Root: "/redfish/v1",
+			ExcludeRules: []string{
+				"/JsonSchemas",
+				"/Accounts",
+				"/Certificates",
+				"/Jobs",
+				"/Logs",
+				"/Registries",
+				"/Roles",
+				"/Sessions",
+				"/Settings",
+				"/AccountService",
+				"/CertificateService",
+				"/EventService",
+				"/JobService",
+				"/LogServices",
+				"/SessionService",
+				"/TaskService",
+				"/TelemetryService",
+				"/UpdateService",
+				"/Power/",
+				"/Power#/",
+				"/Thermal#/",
+				"/Assembly#/",
+				"/redfish/v1/Chassis/$",
+			},
+		},
+		MetricRules: []*MetricRule{
+			{
+				Path: "/redfish/v1/Chassis/{chassis}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_networkadapters_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_networkadapters_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkDeviceFunctions/{function}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_networkadapters_networkdevicefunctions_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_networkadapters_networkdevicefunctions_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkPorts/{port}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_networkadapters_networkports_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_networkadapters_networkports_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/PCIeSlots",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Slots/{slot}/Status/State",
+						Name:    "chassis_pcieslots_slots_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/Power",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/PowerControl/{powercontrol}/PowerConsumedWatts",
+						Name:    "chassis_power_powercontrol_powerconsumedwatts",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/Health",
+						Name:    "chassis_power_powersupplies_redundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/State",
+						Name:    "chassis_power_powersupplies_redundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Status/Health",
+						Name:    "chassis_power_powersupplies_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Status/State",
+						Name:    "chassis_power_powersupplies_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/Health",
+						Name:    "chassis_power_redundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/State",
+						Name:    "chassis_power_redundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Voltages/{voltage}/Status/Health",
+						Name:    "chassis_power_voltages_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Voltages/{voltage}/Status/State",
+						Name:    "chassis_power_voltages_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/Sensors/{sensor}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_sensors_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_sensors_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/Thermal",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Fans/{fan}/Status/Health",
+						Name:    "chassis_thermal_fans_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Fans/{fan}/Status/State",
+						Name:    "chassis_thermal_fans_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/Health",
+						Name:    "chassis_thermal_redundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/State",
+						Name:    "chassis_thermal_redundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Temperatures/{temperature}/ReadingCelsius",
+						Name:    "chassis_thermal_temperatures_readingcelsius",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Temperatures/{temperature}/Status/Health",
+						Name:    "chassis_thermal_temperatures_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Temperatures/{temperature}/Status/State",
+						Name:    "chassis_thermal_temperatures_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Fabrics/{fabric}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "fabrics_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "fabrics_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "managers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "managers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "managers_ethernetinterfaces_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "managers_ethernetinterfaces_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}/NetworkProtocol",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "managers_networkprotocol_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "managers_networkprotocol_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/HostWatchdogTimer/Status/State",
+						Name:    "systems_hostwatchdogtimer_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/MemorySummary/Status/Health",
+						Name:    "systems_memorysummary_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/MemorySummary/Status/State",
+						Name:    "systems_memorysummary_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/ProcessorSummary/Status/Health",
+						Name:    "systems_processorsummary_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/ProcessorSummary/Status/State",
+						Name:    "systems_processorsummary_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/TrustedModules/{trustedmodule}/Status/State",
+						Name:    "systems_trustedmodules_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/EthernetInterfaces/{interface}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_ethernetinterfaces_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_ethernetinterfaces_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Memory/{memory}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_memory_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_memory_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Memory/{memory}/MemoryMetrics",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/HealthData/AlarmTrips/AddressParityError",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_addressparityerror",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/CorrectableECCError",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_correctableeccerror",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/SpareBlock",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_spareblock",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/Temperature",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_temperature",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/UncorrectableECCError",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_uncorrectableeccerror",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/DataLossDetected",
+						Name:    "systems_memory_memorymetrics_healthdata_datalossdetected",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/PredictedMediaLifeLeftPercent",
+						Name:    "systems_memory_memorymetrics_healthdata_predictedmedialifeleftpercent",
+						Help:    "",
+						Type:    "number",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/NetworkInterfaces/{nic}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_networkinterfaces_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_networkinterfaces_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_pciedevices_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_pciedevices_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}/PCIeFunctions/{function}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_pciedevices_pciefunctions_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_pciedevices_pciefunctions_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Processors/{processor}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_processors_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_processors_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/SimpleStorage/{controller}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Devices/{device}/Status/Health",
+						Name:    "systems_simplestorage_devices_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Devices/{device}/Status/State",
+						Name:    "systems_simplestorage_devices_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_simplestorage_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_simplestorage_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/Drives/{device}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/FailurePredicted",
+						Name:    "systems_storage_drives_failurepredicted",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/PredictedMediaLifeLeftPercent",
+						Name:    "systems_storage_drives_predictedmedialifeleftpercent",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_drives_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_drives_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/StorageControllers/{controller}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_storagecontrollers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_storagecontrollers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/Health",
+						Name:    "systems_storage_storagecontrollers_storagecontrollers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/State",
+						Name:    "systems_storage_storagecontrollers_storagecontrollers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/Volumes/{volume}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_volumes_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_volumes_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+		},
+	},
 	"qemu.yml": {
 		TraverseRule: TraverseRule{
 			Root:         "/redfish/v1",

--- a/redfish/rules/dell_redfish_1.11.0.yml
+++ b/redfish/rules/dell_redfish_1.11.0.yml
@@ -227,12 +227,6 @@ Metrics:
     Type: state
 - Path: /redfish/v1/Systems/{system}/SimpleStorage/{controller}
   Properties:
-  - Name: systems_simplestorage_devices_status_health
-    Pointer: /Devices/{device}/Status/Health
-    Type: health
-  - Name: systems_simplestorage_devices_status_state
-    Pointer: /Devices/{device}/Status/State
-    Type: state
   - Name: systems_simplestorage_status_health
     Pointer: /Status/Health
     Type: health
@@ -246,6 +240,12 @@ Metrics:
     Type: health
   - Name: systems_storage_status_state
     Pointer: /Status/State
+    Type: state
+  - Name: systems_storage_storagecontrollers_status_health
+    Pointer: /StorageControllers/{storagecontroller}/Status/Health
+    Type: health
+  - Name: systems_storage_storagecontrollers_status_state
+    Pointer: /StorageControllers/{storagecontroller}/Status/State
     Type: state
 - Path: /redfish/v1/Systems/{system}/Storage/{storage}/Drives/{device}
   Properties:

--- a/redfish/rules/dell_redfish_1.9.0.yml
+++ b/redfish/rules/dell_redfish_1.9.0.yml
@@ -1,0 +1,311 @@
+Metrics:
+- Path: /redfish/v1/Chassis/{chassis}
+  Properties:
+  - Name: chassis_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}
+  Properties:
+  - Name: chassis_networkadapters_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_networkadapters_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkDeviceFunctions/{function}
+  Properties:
+  - Name: chassis_networkadapters_networkdevicefunctions_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_networkadapters_networkdevicefunctions_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkPorts/{port}
+  Properties:
+  - Name: chassis_networkadapters_networkports_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_networkadapters_networkports_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Chassis/{chassis}/PCIeSlots
+  Properties:
+  - Name: chassis_pcieslots_slots_status_state
+    Pointer: /Slots/{slot}/Status/State
+    Type: state
+- Path: /redfish/v1/Chassis/{chassis}/Power
+  Properties:
+  - Name: chassis_power_powercontrol_powerconsumedwatts
+    Pointer: /PowerControl/{powercontrol}/PowerConsumedWatts
+    Type: number
+  - Name: chassis_power_powersupplies_redundancy_status_health
+    Pointer: /PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/Health
+    Type: health
+  - Name: chassis_power_powersupplies_redundancy_status_state
+    Pointer: /PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/State
+    Type: state
+  - Name: chassis_power_powersupplies_status_health
+    Pointer: /PowerSupplies/{powersupply}/Status/Health
+    Type: health
+  - Name: chassis_power_powersupplies_status_state
+    Pointer: /PowerSupplies/{powersupply}/Status/State
+    Type: state
+  - Name: chassis_power_redundancy_status_health
+    Pointer: /Redundancy/{redundancy}/Status/Health
+    Type: health
+  - Name: chassis_power_redundancy_status_state
+    Pointer: /Redundancy/{redundancy}/Status/State
+    Type: state
+  - Name: chassis_power_voltages_status_health
+    Pointer: /Voltages/{voltage}/Status/Health
+    Type: health
+  - Name: chassis_power_voltages_status_state
+    Pointer: /Voltages/{voltage}/Status/State
+    Type: state
+- Path: /redfish/v1/Chassis/{chassis}/Sensors/{sensor}
+  Properties:
+  - Name: chassis_sensors_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_sensors_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Chassis/{chassis}/Thermal
+  Properties:
+  - Name: chassis_thermal_fans_status_health
+    Pointer: /Fans/{fan}/Status/Health
+    Type: health
+  - Name: chassis_thermal_fans_status_state
+    Pointer: /Fans/{fan}/Status/State
+    Type: state
+  - Name: chassis_thermal_redundancy_status_health
+    Pointer: /Redundancy/{redundancy}/Status/Health
+    Type: health
+  - Name: chassis_thermal_redundancy_status_state
+    Pointer: /Redundancy/{redundancy}/Status/State
+    Type: state
+  - Name: chassis_thermal_temperatures_readingcelsius
+    Pointer: /Temperatures/{temperature}/ReadingCelsius
+    Type: number
+  - Name: chassis_thermal_temperatures_status_health
+    Pointer: /Temperatures/{temperature}/Status/Health
+    Type: health
+  - Name: chassis_thermal_temperatures_status_state
+    Pointer: /Temperatures/{temperature}/Status/State
+    Type: state
+- Path: /redfish/v1/Fabrics/{fabric}
+  Properties:
+  - Name: fabrics_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: fabrics_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Managers/{manager}
+  Properties:
+  - Name: managers_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: managers_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}
+  Properties:
+  - Name: managers_ethernetinterfaces_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: managers_ethernetinterfaces_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Managers/{manager}/NetworkProtocol
+  Properties:
+  - Name: managers_networkprotocol_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: managers_networkprotocol_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}
+  Properties:
+  - Name: systems_hostwatchdogtimer_status_state
+    Pointer: /HostWatchdogTimer/Status/State
+    Type: state
+  - Name: systems_memorysummary_status_health
+    Pointer: /MemorySummary/Status/Health
+    Type: health
+  - Name: systems_memorysummary_status_state
+    Pointer: /MemorySummary/Status/State
+    Type: state
+  - Name: systems_processorsummary_status_health
+    Pointer: /ProcessorSummary/Status/Health
+    Type: health
+  - Name: systems_processorsummary_status_state
+    Pointer: /ProcessorSummary/Status/State
+    Type: state
+  - Name: systems_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_status_state
+    Pointer: /Status/State
+    Type: state
+  - Name: systems_trustedmodules_status_state
+    Pointer: /TrustedModules/{trustedmodule}/Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/EthernetInterfaces/{interface}
+  Properties:
+  - Name: systems_ethernetinterfaces_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_ethernetinterfaces_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/Memory/{memory}
+  Properties:
+  - Name: systems_memory_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_memory_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/Memory/{memory}/MemoryMetrics
+  Properties:
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_addressparityerror
+    Pointer: /HealthData/AlarmTrips/AddressParityError
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_correctableeccerror
+    Pointer: /HealthData/AlarmTrips/CorrectableECCError
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_spareblock
+    Pointer: /HealthData/AlarmTrips/SpareBlock
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_temperature
+    Pointer: /HealthData/AlarmTrips/Temperature
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_uncorrectableeccerror
+    Pointer: /HealthData/AlarmTrips/UncorrectableECCError
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_datalossdetected
+    Pointer: /HealthData/DataLossDetected
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_predictedmedialifeleftpercent
+    Pointer: /HealthData/PredictedMediaLifeLeftPercent
+    Type: number
+- Path: /redfish/v1/Systems/{system}/NetworkInterfaces/{nic}
+  Properties:
+  - Name: systems_networkinterfaces_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_networkinterfaces_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/PCIeDevices/{device}
+  Properties:
+  - Name: systems_pciedevices_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_pciedevices_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/PCIeDevices/{device}/PCIeFunctions/{function}
+  Properties:
+  - Name: systems_pciedevices_pciefunctions_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_pciedevices_pciefunctions_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/Processors/{processor}
+  Properties:
+  - Name: systems_processors_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_processors_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/SimpleStorage/{controller}
+  Properties:
+  - Name: systems_simplestorage_devices_status_health
+    Pointer: /Devices/{device}/Status/Health
+    Type: health
+  - Name: systems_simplestorage_devices_status_state
+    Pointer: /Devices/{device}/Status/State
+    Type: state
+  - Name: systems_simplestorage_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_simplestorage_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/Storage/{storage}
+  Properties:
+  - Name: systems_storage_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_storage_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/Storage/{storage}/Drives/{device}
+  Properties:
+  - Name: systems_storage_drives_failurepredicted
+    Pointer: /FailurePredicted
+    Type: bool
+  - Name: systems_storage_drives_predictedmedialifeleftpercent
+    Pointer: /PredictedMediaLifeLeftPercent
+    Type: number
+  - Name: systems_storage_drives_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_storage_drives_status_state
+    Pointer: /Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/Storage/{storage}/StorageControllers/{controller}
+  Properties:
+  - Name: systems_storage_storagecontrollers_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_storage_storagecontrollers_status_state
+    Pointer: /Status/State
+    Type: state
+  - Name: systems_storage_storagecontrollers_storagecontrollers_status_health
+    Pointer: /StorageControllers/{storagecontroller}/Status/Health
+    Type: health
+  - Name: systems_storage_storagecontrollers_storagecontrollers_status_state
+    Pointer: /StorageControllers/{storagecontroller}/Status/State
+    Type: state
+- Path: /redfish/v1/Systems/{system}/Storage/{storage}/Volumes/{volume}
+  Properties:
+  - Name: systems_storage_volumes_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_storage_volumes_status_state
+    Pointer: /Status/State
+    Type: state
+Traverse:
+  Excludes:
+  - /JsonSchemas
+  - /Accounts
+  - /Certificates
+  - /Jobs
+  - /Logs
+  - /Registries
+  - /Roles
+  - /Sessions
+  - /Settings
+  - /AccountService
+  - /CertificateService
+  - /EventService
+  - /JobService
+  - /LogServices
+  - /SessionService
+  - /TaskService
+  - /TelemetryService
+  - /UpdateService
+  - /Power/
+  - /Power#/
+  - /Thermal#/
+  - /Assembly#/
+  - /redfish/v1/Chassis/$
+  Root: /redfish/v1


### PR DESCRIPTION
- During this update process, iDRAC firmware 5.10.00.00 was released and the redfish version 1.11.0 appeared.
- The branch name is `support-redfish-1.9.0`, but it actually supports 1.11.0.
- Looking at the results of `collector show`, there were no key properties that needed to be added.

Signed-off-by: kouki <kouworld0123@gmail.com>