### PR TITLE
set NPS equals to the number of dies for r6525.

### DIFF
--- a/pkg/setup-hw/dell.go
+++ b/pkg/setup-hw/dell.go
@@ -356,7 +356,7 @@ func (dc *dellConfigurator) configProcessor(ctx context.Context) error {
 			5:  "4",
 			6:  "4",
 			7:  "4",
-			8:  "0",
+			8:  "4", // The optimal value for 8 is "0". We set "4" in order to treat dies == NUMA nodes and avoid cross-die pinning under current K8s Topology Manager. It may be changed in further release of K8s.
 			9:  "4",
 			10: "4",
 			11: "4",


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1684

We want to avoid cross-die pinning in r6525. It can be achieved only by setting die == NUMA node under current K8s Topology Manager.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>