### PR TITLE
Support Redfish API v1.18.0

### DIFF
--- a/base-rules/dell.yaml
+++ b/base-rules/dell.yaml
@@ -4,25 +4,24 @@ Traverse:
     # Schemas
     - /JsonSchemas
     # Non-metric properties
-    - /Accounts
+    - /Assembly
     - /Certificates
     - /Jobs
-    - /Logs
     - /Registries
-    - /Roles
-    - /Sessions
+    - /SecureBoot
     - /Settings
     # Services
     - /AccountService
     - /CertificateService
+    - /DellJobService
     - /EventService
     - /JobService
+    - /LicenseService
     - /LogServices
     - /SessionService
     - /TaskService
     - /TelemetryService
     - /UpdateService
-    - /LicenseService
     # Sub-metrics included in /Power or /Thermal
     - /Power/
     - /Power#/

--- a/redfish/rendered_rules.go
+++ b/redfish/rendered_rules.go
@@ -105,6 +105,28 @@ var Rules = map[string]*CollectRule{
 				},
 			},
 			{
+				Path: "/redfish/v1/Managers/{manager}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "manager_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "manager_network_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+				},
+			},
+			{
 				Path: "/redfish/v1/Systems/{system}",
 				PropertyRules: []*PropertyRule{
 					{
@@ -167,28 +189,6 @@ var Rules = map[string]*CollectRule{
 					{
 						Pointer: "/Devices/{device}/Status/Health",
 						Name:    "storage_device_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Managers/{manager}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "manager_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "manager_network_status_health",
 						Help:    "",
 						Type:    "health",
 					},
@@ -1529,6 +1529,40 @@ var Rules = map[string]*CollectRule{
 				},
 			},
 			{
+				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_pciedevices_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_pciedevices_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}/PCIeFunctions/{function}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_pciedevices_pciefunctions_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_pciedevices_pciefunctions_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
 				Path: "/redfish/v1/Systems/{system}/Processors/{processor}",
 				PropertyRules: []*PropertyRule{
 					{
@@ -1695,35 +1729,876 @@ var Rules = map[string]*CollectRule{
 					},
 				},
 			},
+		},
+	},
+	"dell_redfish_1.18.0.yml": {
+		TraverseRule: TraverseRule{
+			Root: "/redfish/v1",
+			ExcludeRules: []string{
+				"/JsonSchemas",
+				"/Assembly",
+				"/Certificates",
+				"/Jobs",
+				"/Registries",
+				"/SecureBoot",
+				"/Settings",
+				"/AccountService",
+				"/CertificateService",
+				"/DellJobService",
+				"/EventService",
+				"/JobService",
+				"/LicenseService",
+				"/LogServices",
+				"/SessionService",
+				"/TaskService",
+				"/TelemetryService",
+				"/UpdateService",
+				"/Power/",
+				"/Power#/",
+				"/Thermal#/",
+				"/Assembly#/",
+				"/redfish/v1/Chassis/$",
+			},
+		},
+		MetricRules: []*MetricRule{
 			{
-				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}",
+				Path: "/redfish/v1/Chassis/{chassis}",
 				PropertyRules: []*PropertyRule{
 					{
 						Pointer: "/Status/Health",
-						Name:    "systems_pciedevices_status_health",
+						Name:    "chassis_status_health",
 						Help:    "",
 						Type:    "health",
 					},
 					{
 						Pointer: "/Status/State",
-						Name:    "systems_pciedevices_status_state",
+						Name:    "chassis_status_state",
 						Help:    "",
 						Type:    "state",
 					},
 				},
 			},
 			{
-				Path: "/redfish/v1/Systems/{system}/PCIeDevices/{device}/PCIeFunctions/{function}",
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}",
 				PropertyRules: []*PropertyRule{
 					{
 						Pointer: "/Status/Health",
-						Name:    "systems_pciedevices_pciefunctions_status_health",
+						Name:    "chassis_networkadapters_status_health",
 						Help:    "",
 						Type:    "health",
 					},
 					{
 						Pointer: "/Status/State",
-						Name:    "systems_pciedevices_pciefunctions_status_state",
+						Name:    "chassis_networkadapters_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkDeviceFunctions/{function}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_networkadapters_networkdevicefunctions_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_networkadapters_networkdevicefunctions_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkPorts/{port}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_networkadapters_networkports_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_networkadapters_networkports_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/Ports/{port}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_networkadapters_ports_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_networkadapters_ports_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/PCIeDevices/{device}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_pciedevices_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_pciedevices_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/PCIeDevices/{device}/PCIeFunctions/{function}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_pciedevices_pciefunctions_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_pciedevices_pciefunctions_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/PCIeSlots",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Slots/{slot}/Status/State",
+						Name:    "chassis_pcieslots_slots_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/Power",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/PowerControl/{powercontrol}/PowerConsumedWatts",
+						Name:    "chassis_power_powercontrol_powerconsumedwatts",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/Health",
+						Name:    "chassis_power_powersupplies_redundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/State",
+						Name:    "chassis_power_powersupplies_redundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Status/Health",
+						Name:    "chassis_power_powersupplies_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/PowerSupplies/{powersupply}/Status/State",
+						Name:    "chassis_power_powersupplies_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/Health",
+						Name:    "chassis_power_redundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/State",
+						Name:    "chassis_power_redundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Voltages/{voltage}/Status/Health",
+						Name:    "chassis_power_voltages_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Voltages/{voltage}/Status/State",
+						Name:    "chassis_power_voltages_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/PowerSubsystem",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/PowerSupplyRedundancy/{powersupplyredundancy}/Status/Health",
+						Name:    "chassis_powersubsystem_powersupplyredundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/PowerSupplyRedundancy/{powersupplyredundancy}/Status/State",
+						Name:    "chassis_powersubsystem_powersupplyredundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_powersubsystem_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_powersubsystem_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/PowerSubsystem/PowerSupplies/{unit}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_powersubsystem_powersupplies_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_powersubsystem_powersupplies_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/PowerSubsystem/PowerSupplies/{unit}/Metrics",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/FrequencyHz/Reading",
+						Name:    "chassis_powersubsystem_powersupplies_metrics_frequencyhz_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/InputCurrentAmps/Reading",
+						Name:    "chassis_powersubsystem_powersupplies_metrics_inputcurrentamps_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/InputPowerWatts/Reading",
+						Name:    "chassis_powersubsystem_powersupplies_metrics_inputpowerwatts_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/InputVoltage/Reading",
+						Name:    "chassis_powersubsystem_powersupplies_metrics_inputvoltage_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/OutputPowerWatts/Reading",
+						Name:    "chassis_powersubsystem_powersupplies_metrics_outputpowerwatts_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_powersubsystem_powersupplies_metrics_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_powersubsystem_powersupplies_metrics_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/Sensors/{sensor}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Reading",
+						Name:    "chassis_sensors_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_sensors_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_sensors_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Thresholds/LowerCaution/Reading",
+						Name:    "chassis_sensors_thresholds_lowercaution_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Thresholds/LowerCritical/Reading",
+						Name:    "chassis_sensors_thresholds_lowercritical_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Thresholds/UpperCaution/Reading",
+						Name:    "chassis_sensors_thresholds_uppercaution_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Thresholds/UpperCritical/Reading",
+						Name:    "chassis_sensors_thresholds_uppercritical_reading",
+						Help:    "",
+						Type:    "number",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/Thermal",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Fans/{fan}/Reading",
+						Name:    "chassis_thermal_fans_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Fans/{fan}/Status/Health",
+						Name:    "chassis_thermal_fans_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Fans/{fan}/Status/State",
+						Name:    "chassis_thermal_fans_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/Health",
+						Name:    "chassis_thermal_redundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Redundancy/{redundancy}/Status/State",
+						Name:    "chassis_thermal_redundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Temperatures/{temperature}/ReadingCelsius",
+						Name:    "chassis_thermal_temperatures_readingcelsius",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Temperatures/{temperature}/Status/Health",
+						Name:    "chassis_thermal_temperatures_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Temperatures/{temperature}/Status/State",
+						Name:    "chassis_thermal_temperatures_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/ThermalSubsystem",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/FanRedundancy/{fanredundancy}/Status/Health",
+						Name:    "chassis_thermalsubsystem_fanredundancy_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/FanRedundancy/{fanredundancy}/Status/State",
+						Name:    "chassis_thermalsubsystem_fanredundancy_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_thermalsubsystem_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_thermalsubsystem_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/ThermalSubsystem/Fans/{unit}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "chassis_thermalsubsystem_fans_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "chassis_thermalsubsystem_fans_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Chassis/{chassis}/ThermalSubsystem/ThermalMetrics",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/TemperatureReadingsCelsius/{temperaturereadingscelsiu}/Reading",
+						Name:    "chassis_thermalsubsystem_thermalmetrics_temperaturereadingscelsius_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/TemperatureSummaryCelsius/Exhaust/Reading",
+						Name:    "chassis_thermalsubsystem_thermalmetrics_temperaturesummarycelsius_exhaust_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/TemperatureSummaryCelsius/Intake/Reading",
+						Name:    "chassis_thermalsubsystem_thermalmetrics_temperaturesummarycelsius_intake_reading",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/TemperatureSummaryCelsius/Internal/Reading",
+						Name:    "chassis_thermalsubsystem_thermalmetrics_temperaturesummarycelsius_internal_reading",
+						Help:    "",
+						Type:    "number",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Fabrics/{fabric}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "fabrics_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "fabrics_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "managers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "managers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "managers_ethernetinterfaces_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "managers_ethernetinterfaces_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}/NetworkProtocol",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "managers_networkprotocol_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "managers_networkprotocol_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/HostWatchdogTimer/Status/State",
+						Name:    "systems_hostwatchdogtimer_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/MemorySummary/Status/Health",
+						Name:    "systems_memorysummary_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/MemorySummary/Status/State",
+						Name:    "systems_memorysummary_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/ProcessorSummary/Status/Health",
+						Name:    "systems_processorsummary_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/ProcessorSummary/Status/State",
+						Name:    "systems_processorsummary_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/TrustedModules/{trustedmodule}/Status/State",
+						Name:    "systems_trustedmodules_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/EthernetInterfaces/{interface}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_ethernetinterfaces_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_ethernetinterfaces_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Memory/{memory}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_memory_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_memory_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Memory/{memory}/MemoryMetrics",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/HealthData/AlarmTrips/AddressParityError",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_addressparityerror",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/CorrectableECCError",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_correctableeccerror",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/SpareBlock",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_spareblock",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/Temperature",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_temperature",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/AlarmTrips/UncorrectableECCError",
+						Name:    "systems_memory_memorymetrics_healthdata_alarmtrips_uncorrectableeccerror",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/DataLossDetected",
+						Name:    "systems_memory_memorymetrics_healthdata_datalossdetected",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/HealthData/PredictedMediaLifeLeftPercent",
+						Name:    "systems_memory_memorymetrics_healthdata_predictedmedialifeleftpercent",
+						Help:    "",
+						Type:    "number",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/NetworkInterfaces/{nic}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_networkinterfaces_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_networkinterfaces_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Processors/{processor}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_processors_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_processors_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/SimpleStorage/{controller}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Devices/{device}/Status/Health",
+						Name:    "systems_simplestorage_devices_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Devices/{device}/Status/State",
+						Name:    "systems_simplestorage_devices_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_simplestorage_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_simplestorage_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/Health",
+						Name:    "systems_storage_storagecontrollers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/State",
+						Name:    "systems_storage_storagecontrollers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/Controllers/{controller}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_controllers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_controllers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/Drives/{device}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/FailurePredicted",
+						Name:    "systems_storage_drives_failurepredicted",
+						Help:    "",
+						Type:    "bool",
+					},
+					{
+						Pointer: "/PredictedMediaLifeLeftPercent",
+						Name:    "systems_storage_drives_predictedmedialifeleftpercent",
+						Help:    "",
+						Type:    "number",
+					},
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_drives_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_drives_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/StorageControllers/{controller}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_storagecontrollers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_storagecontrollers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/Health",
+						Name:    "systems_storage_storagecontrollers_storagecontrollers_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/StorageControllers/{storagecontroller}/Status/State",
+						Name:    "systems_storage_storagecontrollers_storagecontrollers_status_state",
+						Help:    "",
+						Type:    "state",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Systems/{system}/Storage/{storage}/Volumes/{volume}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "systems_storage_volumes_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+					{
+						Pointer: "/Status/State",
+						Name:    "systems_storage_volumes_status_state",
 						Help:    "",
 						Type:    "state",
 					},
@@ -1820,6 +2695,28 @@ var Rules = map[string]*CollectRule{
 				},
 			},
 			{
+				Path: "/redfish/v1/Managers/{manager}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "manager_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+				},
+			},
+			{
+				Path: "/redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}",
+				PropertyRules: []*PropertyRule{
+					{
+						Pointer: "/Status/Health",
+						Name:    "manager_network_status_health",
+						Help:    "",
+						Type:    "health",
+					},
+				},
+			},
+			{
 				Path: "/redfish/v1/Systems/{system}",
 				PropertyRules: []*PropertyRule{
 					{
@@ -1871,17 +2768,6 @@ var Rules = map[string]*CollectRule{
 				},
 			},
 			{
-				Path: "/redfish/v1/Systems/{system}/Storage/{controller}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "storage_controller_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-				},
-			},
-			{
 				Path: "/redfish/v1/Systems/{system}/Storage/Drives/{device}",
 				PropertyRules: []*PropertyRule{
 					{
@@ -1893,22 +2779,11 @@ var Rules = map[string]*CollectRule{
 				},
 			},
 			{
-				Path: "/redfish/v1/Managers/{manager}",
+				Path: "/redfish/v1/Systems/{system}/Storage/{controller}",
 				PropertyRules: []*PropertyRule{
 					{
 						Pointer: "/Status/Health",
-						Name:    "manager_status_health",
-						Help:    "",
-						Type:    "health",
-					},
-				},
-			},
-			{
-				Path: "/redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}",
-				PropertyRules: []*PropertyRule{
-					{
-						Pointer: "/Status/Health",
-						Name:    "manager_network_status_health",
+						Name:    "storage_controller_status_health",
 						Help:    "",
 						Type:    "health",
 					},

--- a/redfish/rules/dell_redfish_1.18.0.yml
+++ b/redfish/rules/dell_redfish_1.18.0.yml
@@ -1,0 +1,465 @@
+Traverse:
+  Root: /redfish/v1
+  Excludes:
+  - /JsonSchemas
+  - /Assembly
+  - /Certificates
+  - /Jobs
+  - /Registries
+  - /SecureBoot
+  - /Settings
+  - /AccountService
+  - /CertificateService
+  - /DellJobService
+  - /EventService
+  - /JobService
+  - /LicenseService
+  - /LogServices
+  - /SessionService
+  - /TaskService
+  - /TelemetryService
+  - /UpdateService
+  - /Power/
+  - /Power#/
+  - /Thermal#/
+  - /Assembly#/
+  - /redfish/v1/Chassis/$
+
+Metrics:
+- Path: /redfish/v1/Chassis/{chassis}
+  Properties:
+  - Name: chassis_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}
+  Properties:
+  - Name: chassis_networkadapters_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_networkadapters_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkDeviceFunctions/{function}
+  Properties:
+  - Name: chassis_networkadapters_networkdevicefunctions_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_networkadapters_networkdevicefunctions_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/NetworkPorts/{port}
+  Properties:
+  - Name: chassis_networkadapters_networkports_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_networkadapters_networkports_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/NetworkAdapters/{nic}/Ports/{port}
+  Properties:
+  - Name: chassis_networkadapters_ports_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_networkadapters_ports_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/PCIeDevices/{device}
+  Properties:
+  - Name: chassis_pciedevices_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_pciedevices_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/PCIeDevices/{device}/PCIeFunctions/{function}
+  Properties:
+  - Name: chassis_pciedevices_pciefunctions_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_pciedevices_pciefunctions_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/PCIeSlots
+  Properties:
+  - Name: chassis_pcieslots_slots_status_state
+    Pointer: /Slots/{slot}/Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/Power
+  Properties:
+  - Name: chassis_power_powercontrol_powerconsumedwatts
+    Pointer: /PowerControl/{powercontrol}/PowerConsumedWatts
+    Type: number
+  - Name: chassis_power_powersupplies_redundancy_status_health
+    Pointer: /PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/Health
+    Type: health
+  - Name: chassis_power_powersupplies_redundancy_status_state
+    Pointer: /PowerSupplies/{powersupply}/Redundancy/{redundancy}/Status/State
+    Type: state
+  - Name: chassis_power_powersupplies_status_health
+    Pointer: /PowerSupplies/{powersupply}/Status/Health
+    Type: health
+  - Name: chassis_power_powersupplies_status_state
+    Pointer: /PowerSupplies/{powersupply}/Status/State
+    Type: state
+  - Name: chassis_power_redundancy_status_health
+    Pointer: /Redundancy/{redundancy}/Status/Health
+    Type: health
+  - Name: chassis_power_redundancy_status_state
+    Pointer: /Redundancy/{redundancy}/Status/State
+    Type: state
+  - Name: chassis_power_voltages_status_health
+    Pointer: /Voltages/{voltage}/Status/Health
+    Type: health
+  - Name: chassis_power_voltages_status_state
+    Pointer: /Voltages/{voltage}/Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/PowerSubsystem
+  Properties:
+  - Name: chassis_powersubsystem_powersupplyredundancy_status_health
+    Pointer: /PowerSupplyRedundancy/{powersupplyredundancy}/Status/Health
+    Type: health
+  - Name: chassis_powersubsystem_powersupplyredundancy_status_state
+    Pointer: /PowerSupplyRedundancy/{powersupplyredundancy}/Status/State
+    Type: state
+  - Name: chassis_powersubsystem_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_powersubsystem_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/PowerSubsystem/PowerSupplies/{unit}
+  Properties:
+  - Name: chassis_powersubsystem_powersupplies_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_powersubsystem_powersupplies_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/PowerSubsystem/PowerSupplies/{unit}/Metrics
+  Properties:
+  - Name: chassis_powersubsystem_powersupplies_metrics_frequencyhz_reading
+    Pointer: /FrequencyHz/Reading
+    Type: number
+  - Name: chassis_powersubsystem_powersupplies_metrics_inputcurrentamps_reading
+    Pointer: /InputCurrentAmps/Reading
+    Type: number
+  - Name: chassis_powersubsystem_powersupplies_metrics_inputpowerwatts_reading
+    Pointer: /InputPowerWatts/Reading
+    Type: number
+  - Name: chassis_powersubsystem_powersupplies_metrics_inputvoltage_reading
+    Pointer: /InputVoltage/Reading
+    Type: number
+  - Name: chassis_powersubsystem_powersupplies_metrics_outputpowerwatts_reading
+    Pointer: /OutputPowerWatts/Reading
+    Type: number
+  - Name: chassis_powersubsystem_powersupplies_metrics_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_powersubsystem_powersupplies_metrics_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/Sensors/{sensor}
+  Properties:
+  - Name: chassis_sensors_reading
+    Pointer: /Reading
+    Type: number
+  - Name: chassis_sensors_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_sensors_status_state
+    Pointer: /Status/State
+    Type: state
+  - Name: chassis_sensors_thresholds_lowercaution_reading
+    Pointer: /Thresholds/LowerCaution/Reading
+    Type: number
+  - Name: chassis_sensors_thresholds_lowercritical_reading
+    Pointer: /Thresholds/LowerCritical/Reading
+    Type: number
+  - Name: chassis_sensors_thresholds_uppercaution_reading
+    Pointer: /Thresholds/UpperCaution/Reading
+    Type: number
+  - Name: chassis_sensors_thresholds_uppercritical_reading
+    Pointer: /Thresholds/UpperCritical/Reading
+    Type: number
+
+- Path: /redfish/v1/Chassis/{chassis}/Thermal
+  Properties:
+  - Name: chassis_thermal_fans_reading
+    Pointer: /Fans/{fan}/Reading
+    Type: number
+  - Name: chassis_thermal_fans_status_health
+    Pointer: /Fans/{fan}/Status/Health
+    Type: health
+  - Name: chassis_thermal_fans_status_state
+    Pointer: /Fans/{fan}/Status/State
+    Type: state
+  - Name: chassis_thermal_redundancy_status_health
+    Pointer: /Redundancy/{redundancy}/Status/Health
+    Type: health
+  - Name: chassis_thermal_redundancy_status_state
+    Pointer: /Redundancy/{redundancy}/Status/State
+    Type: state
+  - Name: chassis_thermal_temperatures_readingcelsius
+    Pointer: /Temperatures/{temperature}/ReadingCelsius
+    Type: number
+  - Name: chassis_thermal_temperatures_status_health
+    Pointer: /Temperatures/{temperature}/Status/Health
+    Type: health
+  - Name: chassis_thermal_temperatures_status_state
+    Pointer: /Temperatures/{temperature}/Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/ThermalSubsystem
+  Properties:
+  - Name: chassis_thermalsubsystem_fanredundancy_status_health
+    Pointer: /FanRedundancy/{fanredundancy}/Status/Health
+    Type: health
+  - Name: chassis_thermalsubsystem_fanredundancy_status_state
+    Pointer: /FanRedundancy/{fanredundancy}/Status/State
+    Type: state
+  - Name: chassis_thermalsubsystem_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_thermalsubsystem_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/ThermalSubsystem/Fans/{unit}
+  Properties:
+  - Name: chassis_thermalsubsystem_fans_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: chassis_thermalsubsystem_fans_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Chassis/{chassis}/ThermalSubsystem/ThermalMetrics
+  Properties:
+  - Name: chassis_thermalsubsystem_thermalmetrics_temperaturereadingscelsius_reading
+    Pointer: /TemperatureReadingsCelsius/{temperaturereadingscelsiu}/Reading
+    Type: number
+  - Name: chassis_thermalsubsystem_thermalmetrics_temperaturesummarycelsius_exhaust_reading
+    Pointer: /TemperatureSummaryCelsius/Exhaust/Reading
+    Type: number
+  - Name: chassis_thermalsubsystem_thermalmetrics_temperaturesummarycelsius_intake_reading
+    Pointer: /TemperatureSummaryCelsius/Intake/Reading
+    Type: number
+  - Name: chassis_thermalsubsystem_thermalmetrics_temperaturesummarycelsius_internal_reading
+    Pointer: /TemperatureSummaryCelsius/Internal/Reading
+    Type: number
+
+- Path: /redfish/v1/Fabrics/{fabric}
+  Properties:
+  - Name: fabrics_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: fabrics_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Managers/{manager}
+  Properties:
+  - Name: managers_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: managers_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Managers/{manager}/EthernetInterfaces/{interface}
+  Properties:
+  - Name: managers_ethernetinterfaces_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: managers_ethernetinterfaces_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Managers/{manager}/NetworkProtocol
+  Properties:
+  - Name: managers_networkprotocol_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: managers_networkprotocol_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}
+  Properties:
+  - Name: systems_hostwatchdogtimer_status_state
+    Pointer: /HostWatchdogTimer/Status/State
+    Type: state
+  - Name: systems_memorysummary_status_health
+    Pointer: /MemorySummary/Status/Health
+    Type: health
+  - Name: systems_memorysummary_status_state
+    Pointer: /MemorySummary/Status/State
+    Type: state
+  - Name: systems_processorsummary_status_health
+    Pointer: /ProcessorSummary/Status/Health
+    Type: health
+  - Name: systems_processorsummary_status_state
+    Pointer: /ProcessorSummary/Status/State
+    Type: state
+  - Name: systems_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_status_state
+    Pointer: /Status/State
+    Type: state
+  - Name: systems_trustedmodules_status_state
+    Pointer: /TrustedModules/{trustedmodule}/Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/EthernetInterfaces/{interface}
+  Properties:
+  - Name: systems_ethernetinterfaces_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_ethernetinterfaces_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/Memory/{memory}
+  Properties:
+  - Name: systems_memory_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_memory_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/Memory/{memory}/MemoryMetrics
+  Properties:
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_addressparityerror
+    Pointer: /HealthData/AlarmTrips/AddressParityError
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_correctableeccerror
+    Pointer: /HealthData/AlarmTrips/CorrectableECCError
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_spareblock
+    Pointer: /HealthData/AlarmTrips/SpareBlock
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_temperature
+    Pointer: /HealthData/AlarmTrips/Temperature
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_alarmtrips_uncorrectableeccerror
+    Pointer: /HealthData/AlarmTrips/UncorrectableECCError
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_datalossdetected
+    Pointer: /HealthData/DataLossDetected
+    Type: bool
+  - Name: systems_memory_memorymetrics_healthdata_predictedmedialifeleftpercent
+    Pointer: /HealthData/PredictedMediaLifeLeftPercent
+    Type: number
+
+- Path: /redfish/v1/Systems/{system}/NetworkInterfaces/{nic}
+  Properties:
+  - Name: systems_networkinterfaces_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_networkinterfaces_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/Processors/{processor}
+  Properties:
+  - Name: systems_processors_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_processors_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/SimpleStorage/{controller}
+  Properties:
+  - Name: systems_simplestorage_devices_status_health
+    Pointer: /Devices/{device}/Status/Health
+    Type: health
+  - Name: systems_simplestorage_devices_status_state
+    Pointer: /Devices/{device}/Status/State
+    Type: state
+  - Name: systems_simplestorage_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_simplestorage_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/Storage/{storage}
+  Properties:
+  - Name: systems_storage_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_storage_status_state
+    Pointer: /Status/State
+    Type: state
+  - Name: systems_storage_storagecontrollers_status_health
+    Pointer: /StorageControllers/{storagecontroller}/Status/Health
+    Type: health
+  - Name: systems_storage_storagecontrollers_status_state
+    Pointer: /StorageControllers/{storagecontroller}/Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/Storage/{storage}/Controllers/{controller}
+  Properties:
+  - Name: systems_storage_controllers_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_storage_controllers_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/Storage/{storage}/Drives/{device}
+  Properties:
+  - Name: systems_storage_drives_failurepredicted
+    Pointer: /FailurePredicted
+    Type: bool
+  - Name: systems_storage_drives_predictedmedialifeleftpercent
+    Pointer: /PredictedMediaLifeLeftPercent
+    Type: number
+  - Name: systems_storage_drives_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_storage_drives_status_state
+    Pointer: /Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/Storage/{storage}/StorageControllers/{controller}
+  Properties:
+  - Name: systems_storage_storagecontrollers_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_storage_storagecontrollers_status_state
+    Pointer: /Status/State
+    Type: state
+  - Name: systems_storage_storagecontrollers_storagecontrollers_status_health
+    Pointer: /StorageControllers/{storagecontroller}/Status/Health
+    Type: health
+  - Name: systems_storage_storagecontrollers_storagecontrollers_status_state
+    Pointer: /StorageControllers/{storagecontroller}/Status/State
+    Type: state
+
+- Path: /redfish/v1/Systems/{system}/Storage/{storage}/Volumes/{volume}
+  Properties:
+  - Name: systems_storage_volumes_status_health
+    Pointer: /Status/Health
+    Type: health
+  - Name: systems_storage_volumes_status_state
+    Pointer: /Status/State
+    Type: state


### PR DESCRIPTION
This PR adds a new rule for Redfish v1.18.0.

As far as I checked, there was no significant difference between Redfish v1.17.0 and v1.18.0.
Redfish v1.18.0 introduces the ComponentIntegrity API, but the actual machines did not provide any useful values.
Therefore, the rules are almost the same as in v1.17.0.

```
$ diff -u redfish_1.17.0_RootService.json redfish_1.18.0_RootService.json
--- redfish_1.17.0_RootService.json     2024-06-07 17:41:56.756896477 +0900
+++ redfish_1.18.0_RootService.json     2024-06-07 17:43:31.866891713 +0900
@@ -1,7 +1,7 @@
 {
   "@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
   "@odata.id": "/redfish/v1",
-  "@odata.type": "#ServiceRoot.v1_15_0.ServiceRoot",
+  "@odata.type": "#ServiceRoot.v1_16_0.ServiceRoot",
   "AccountService": {
     "@odata.id": "/redfish/v1/AccountService"
   },
@@ -11,6 +11,9 @@
   "Chassis": {
     "@odata.id": "/redfish/v1/Chassis"
   },
+  "ComponentIntegrity": {
+    "@odata.id": "/redfish/v1/ComponentIntegrity"
+  },
   "Description": "Root Service",
   "EventService": {
     "@odata.id": "/redfish/v1/EventService"
@@ -64,7 +67,7 @@
     "OnlyMemberQuery": true,
     "SelectQuery": true
   },
-  "RedfishVersion": "1.17.0",
+  "RedfishVersion": "1.18.0",
   "Registries": {
     "@odata.id": "/redfish/v1/Registries"
   },
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>