### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      
+      - name: setup
+        run: make setup 
 
       - name: Build binaries
         run: make install GOBIN=`pwd`/docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [1.17.2] - 2024-11-27
+## [1.17.2] - 2024-11-28
 
 ### Changed
 
 - Update dependencies ([#116](https://github.com/cybozu-go/setup-hw/pull/116))
   - Update go module dependencies
   - Update ubuntu version in Dockerfile
+- Fix release workflow ([#118](https://github.com/cybozu-go/setup-hw/pull/118))
 
 ## [1.17.1] - 2024-07-19
 


### PR DESCRIPTION
The issue was that the `go generate ./redfish/...` command was executed without the `goimports` command being installed in the release workflow, causing the CI to fail. 
I have fixed the release workflow to ensure that dependent commands are installed beforehand. 
Since the release of version 1.17.2 failed, I plan to re-tag and release version 1.17.2 again after merging this PR.