### PR TITLE
add config for 16G server

### DIFF
--- a/lib/vendor.go
+++ b/lib/vendor.go
@@ -43,6 +43,8 @@ const (
 	Other Product = iota
 	R6525
 	R7525
+	R6615
+	R7615
 )
 
 // DetectProduct detects product name.
@@ -57,6 +59,10 @@ func DetectProduct() (Product, error) {
 		return R6525, nil
 	case strings.Contains(product, "R7525"):
 		return R7525, nil
+	case strings.Contains(product, "R6615"):
+		return R6615, nil
+	case strings.Contains(product, "R7615"):
+		return R7615, nil
 	default:
 		return Other, nil
 	}

--- a/pkg/setup-hw/dell.go
+++ b/pkg/setup-hw/dell.go
@@ -330,9 +330,9 @@ func (dc *dellConfigurator) configPerformance(ctx context.Context) error {
 		return err
 	}
 	switch product {
-	case lib.R6525, lib.R7525:
+	case lib.R6525, lib.R7525, lib.R7615:
 		return dc.enqueueConfig(ctx, "BIOS.SysProfileSettings.SysProfile", "PerfPerWattOptimizedOs")
-	case lib.R6615, lib.R7615:
+	case lib.R6615: // In 16G server, we cannot disable power saving function even if we set cpu-governor. We need set System Profile to Performance.
 		return dc.enqueueConfig(ctx, "BIOS.SysProfileSettings.SysProfile", "PerfOptimized")
 	default:
 		return fmt.Errorf("unsupported product: %v", product)

--- a/pkg/setup-hw/dell.go
+++ b/pkg/setup-hw/dell.go
@@ -335,7 +335,10 @@ func (dc *dellConfigurator) configPerformance(ctx context.Context) error {
 	case lib.R6615: // In 16G server, we cannot disable power saving function even if we set cpu-governor. We need set System Profile to Performance.
 		return dc.enqueueConfig(ctx, "BIOS.SysProfileSettings.SysProfile", "PerfOptimized")
 	default:
-		return fmt.Errorf("unsupported product: %v", product)
+		log.Warn("unsupported product, skipping setting of SysProfile", map[string]interface{}{
+			"product": product,
+		})
+		return nil
 	}
 }
 

--- a/pkg/setup-hw/dell.go
+++ b/pkg/setup-hw/dell.go
@@ -325,7 +325,18 @@ func (dc *dellConfigurator) configBIOS(ctx context.Context) error {
 }
 
 func (dc *dellConfigurator) configPerformance(ctx context.Context) error {
-	return dc.enqueueConfig(ctx, "BIOS.SysProfileSettings.SysProfile", "PerfPerWattOptimizedOs")
+	product, err := lib.DetectProduct()
+	if err != nil {
+		return err
+	}
+	switch product {
+	case lib.R6525, lib.R7525:
+		return dc.enqueueConfig(ctx, "BIOS.SysProfileSettings.SysProfile", "PerfPerWattOptimizedOs")
+	case lib.R6615, lib.R7615:
+		return dc.enqueueConfig(ctx, "BIOS.SysProfileSettings.SysProfile", "PerfOptimized")
+	default:
+		return fmt.Errorf("unsupported product: %v", product)
+	}
 }
 
 func (dc *dellConfigurator) configProcessor(ctx context.Context) error {
@@ -384,6 +395,8 @@ func (dc *dellConfigurator) configProcessor(ctx context.Context) error {
 			npsVal = "1"
 		}
 		return dc.enqueueConfig(ctx, "BIOS.ProcSettings.NumaNodesPerSocket", npsVal)
+	case lib.R6615, lib.R7615:
+		return dc.enqueueConfig(ctx, "BIOS.ProcSettings.NumaNodesPerSocket", "1")
 	default:
 		return nil
 	}


### PR DESCRIPTION
In 16G server, we cannot disable power saving function even if we set cpu-governor. We need set System Profile to Performance.