### PR TITLE
change authentication x-auth-token

### DIFF
--- a/redfish/collector.go
+++ b/redfish/collector.go
@@ -16,6 +16,7 @@ const namespace = "hw"
 type Client interface {
 	Traverse(ctx context.Context, rule *CollectRule) Collected
 	GetVersion(ctx context.Context) (string, error)
+	Login(ctx context.Context) error
 }
 
 // NewCollected creates a new Collected instance
@@ -89,6 +90,7 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 // Update collects metrics from BMCs via Redfish.
 func (c *Collector) Update(ctx context.Context) {
 	log.Info("getting rule", nil)
+	c.client.Login(ctx)
 	rule, err := c.ruleGetter(ctx)
 	if err != nil {
 		log.Error("failed to get rule", map[string]interface{}{

--- a/redfish/mock.go
+++ b/redfish/mock.go
@@ -116,3 +116,7 @@ func (c *mockClient) Traverse(ctx context.Context, rule *CollectRule) Collected 
 func (c *mockClient) GetVersion(ctx context.Context) (string, error) {
 	return "1.0.0", nil
 }
+
+func (c *mockClient) Login(ctx context.Context) error {
+	return nil
+}

--- a/redfish/stub_client_test.go
+++ b/redfish/stub_client_test.go
@@ -89,3 +89,7 @@ func (c *stubClient) Traverse(ctx context.Context, rule *CollectRule) Collected 
 func (c *stubClient) GetVersion(ctx context.Context) (string, error) {
 	return "1.0.0", nil
 }
+
+func (c *stubClient) Login(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
I have changed the basic authentication for accessing iDRAC Redfish to X-Auth-Token authentication.

This will resolve the Life Cycle Log overflow issue.

 