### PR TITLE
collector: add login step before traversal in collectOrLoad

### DIFF
--- a/pkg/collector/cmd/input.go
+++ b/pkg/collector/cmd/input.go
@@ -52,6 +52,7 @@ func collectOrLoad(ctx context.Context, inputFile string, baseRule string) (*red
 		if err != nil {
 			return nil, err
 		}
+		client.Login(ctx)
 
 		collected := client.Traverse(ctx, rule)
 		return &collected, nil


### PR DESCRIPTION
Fix the authentication error in collector.
This is likely due to the https://github.com/cybozu-go/setup-hw/pull/147.