### PR TITLE
Use iDRAC packages for Ubuntu 24.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Use iDRAC packages for Ubuntu 24.04 in [#167](https://github.com/cybozu-go/setup-hw/pull/167)
+
 ## [1.30.0] - 2026-05-20
 
 ## Changed

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends pciutils libargtable2-0 kmod dmidecode
 
 RUN mkdir /pkg
-COPY iDRACTools/racadm/UBUNTU22/x86_64/*.deb /pkg/
+COPY iDRACTools/racadm/UBUNTU24/x86_64/*.deb /pkg/
 RUN dpkg -i /pkg/srvadmin-hapi_11.4.0.0_amd64.deb \
     && dpkg -i /pkg/srvadmin-idracadm7_11.4.0.0_all.deb \
     && dpkg -i /pkg/srvadmin-idracadm8_11.4.0.0_amd64.deb


### PR DESCRIPTION
Now setup-hw uses the wrong package, so I'll fix it.
This bug is introduced in https://github.com/cybozu-go/setup-hw/pull/157.